### PR TITLE
Added support for whatsapp messaging

### DIFF
--- a/messaging-service.proto
+++ b/messaging-service.proto
@@ -1,0 +1,72 @@
+syntax = "proto3";
+
+option java_multiple_files = true;
+option java_package = "com.kotlang.notification";
+option java_outer_classname = "MessagingServiceInternal";
+
+option go_package = "github.com/Kotlang/notificationGo/generated/notification";
+
+package notification;
+
+service MessagingService {
+
+  // Sends common message to multiple recipients
+  rpc BroadcastMessage (MesssageRequest) returns (StatusResponse);
+
+  // Supports sending unique messages to multiple recipients
+  rpc SendUniqueMessage (UniqueMessageRequest) returns (StatusResponse);
+
+  // Register a new messaging template, these templates can be used as blueprints for sending messages 
+  // and UI rendering in admin panel
+  rpc RegisterMessagingTemplate (RegisterMessagingTemplateRequest) returns (StatusResponse);
+  rpc GetMessagingTemplateById (IdRequest) returns (MessagingTemplate);
+}
+
+enum MediaType {
+  image = 0;
+  video = 1;
+  audio = 2;
+}
+
+message IdRequest {
+  string id = 1;
+}
+
+message StatusResponse {
+  string status = 1;
+}
+
+message MediaParameters {
+  MediaType mediaType = 1;
+  string link = 2;
+  string filename = 3;
+}
+
+message MessagingTemplate {
+  string templateId = 1;
+  string templateName = 2;
+  MediaParameters mediaParameters = 3;
+  map<string, string> templateParameters = 4;
+}
+
+message RegisterMessagingTemplateRequest {
+  string templateId = 1;
+  string templateName = 2;
+  MediaParameters mediaParameters = 3;
+  map<string, string> templateParameters = 4;
+}
+
+// The UniqueMessageRequest is used to send unique messages to multiple recipients
+// The messages are sent to the recipients in the order they are added to the request
+message UniqueMessageRequest {
+  repeated MesssageRequest messages = 1;
+}
+
+// The templateParameters and mediaParameters are merged into a single map named parameters in backend
+// The templateParameters are variables that are used in the template
+message MesssageRequest {
+  string templateId = 1;
+  map<string, string> templateParameters = 2;
+  MediaParameters mediaParameters = 3;
+  repeated string recipientPhoneNumber = 4;
+}

--- a/messaging-service.proto
+++ b/messaging-service.proto
@@ -111,6 +111,12 @@ message UniqueMessageRequest {
   repeated MesssageRequest messages = 1;
 }
 
+// ScheduleInfo is used to schedule messages to be sent at a later time
+message ScheduleInfo {
+  bool isScheduled = 1;
+  int64 scheduledTime = 2;
+}
+
 // The templateParameters and mediaParameters are merged into a single map named parameters in backend
 // The templateParameters are variables that are used in the template
 message MesssageRequest {
@@ -121,7 +127,8 @@ message MesssageRequest {
   MediaParameters mediaParameters = 5;
   repeated string recipientPhoneNumber = 6;
   string wabaid = 7; // WhatsApp Business Account ID
-  string preview = 8; // The message preview 
+  string preview = 8; // The message preview
+  ScheduleInfo scheduleInfo = 9;
 }
 
 message StatusResponse {

--- a/messaging-service.proto
+++ b/messaging-service.proto
@@ -4,21 +4,27 @@ option java_multiple_files = true;
 option java_package = "com.kotlang.notification";
 option java_outer_classname = "MessagingServiceInternal";
 
-option go_package = "github.com/Kotlang/notificationGo/generated/notification";
+option go_package = "github.com/Kotlang/notificationGo/generated";
 
 package notification;
 
+// All messages sent and recieved are saved in the database in the form of Message
+// Template is used to structure the message which is then stored in form of string.
+// Note: Only the variables are passed to the messaging service provider 
 service MessagingService {
 
-  // Sends common message to multiple recipients
+  // Sends common message to multiple recipients or single recipient
   rpc BroadcastMessage (MesssageRequest) returns (StatusResponse);
 
-  // Supports sending unique messages to multiple recipients
+  // Supports sending unique messages to multiple recipients or single recipient
   rpc SendUniqueMessage (UniqueMessageRequest) returns (StatusResponse);
+
+  // Get the chat history of a user
+  rpc GetChatHistory (IdRequest) returns (ChatHistory);
 
   // Register a new messaging template, these templates can be used as blueprints for sending messages 
   // and UI rendering in admin panel
-  rpc RegisterMessagingTemplate (RegisterMessagingTemplateRequest) returns (StatusResponse);
+  rpc RegisterMessagingTemplate (MessagingTemplate) returns (StatusResponse);
   rpc GetMessagingTemplateById (IdRequest) returns (MessagingTemplate);
 }
 
@@ -26,6 +32,12 @@ enum MediaType {
   image = 0;
   video = 1;
   audio = 2;
+}
+
+message MediaParameters {
+  MediaType mediaType = 1;
+  string link = 2;
+  string filename = 3;
 }
 
 message IdRequest {
@@ -36,20 +48,11 @@ message StatusResponse {
   string status = 1;
 }
 
-message MediaParameters {
-  MediaType mediaType = 1;
-  string link = 2;
-  string filename = 3;
-}
-
+// Templates are for validation and rendering in admin panel 
+// The templateId must be the id provided by the service provider (for eg: textlocal)
+// MediaParameters is used to send media files like images, videos, audio
+// templateParameters map contains the variables that are used in the template
 message MessagingTemplate {
-  string templateId = 1;
-  string templateName = 2;
-  MediaParameters mediaParameters = 3;
-  map<string, string> templateParameters = 4;
-}
-
-message RegisterMessagingTemplateRequest {
   string templateId = 1;
   string templateName = 2;
   MediaParameters mediaParameters = 3;
@@ -69,4 +72,17 @@ message MesssageRequest {
   map<string, string> templateParameters = 2;
   MediaParameters mediaParameters = 3;
   repeated string recipientPhoneNumber = 4;
+}
+
+message ChatHistory {
+  repeated Message messages = 1;
+}
+
+message Message {
+  string messageId = 1;
+  string senderId = 2;
+  string recipientId = 3;
+  string message = 4;
+  string status = 5;
+  string createdOn = 6;
 }

--- a/messaging-service.proto
+++ b/messaging-service.proto
@@ -22,7 +22,7 @@ service MessagingService {
   // Register a new messaging template, these templates can be used as blueprints for sending messages 
   // and UI rendering in admin panel
   rpc RegisterMessagingTemplate (MessagingTemplate) returns (StatusResponse);
-  rpc GetMessagingTemplateById (IdRequest) returns (MessagingTemplate);
+  rpc FetchMessagingTemplates (FetchTemplateRequest) returns (MessagingTemplateList);
 }
 
 enum MediaType {
@@ -121,12 +121,21 @@ message MesssageRequest {
   MediaParameters mediaParameters = 5;
   repeated string recipientPhoneNumber = 6;
   string wabaid = 7; // WhatsApp Business Account ID
-}
-
-message IdRequest {
-  string id = 1;
+  string preview = 8; // The message preview 
 }
 
 message StatusResponse {
   string status = 1;
+}
+
+message MessagingTemplateList {
+  repeated MessagingTemplate templates = 1;
+  int32 totalCount = 2;
+}
+
+message FetchTemplateRequest {
+  string templateId = 1;
+  string templateName = 2;
+  int32 pageNumber = 3;
+  int32 pageSize = 4;
 }

--- a/messaging-service.proto
+++ b/messaging-service.proto
@@ -16,6 +16,9 @@ service MessagingService {
   // Sends common message to multiple recipients or single recipient
   rpc BroadcastMessage (MesssageRequest) returns (StatusResponse);
 
+  // Fetch Messages
+  rpc FetchMessages (FetchMessageRequest) returns (MessageList);
+
   // Supports sending unique messages to multiple recipients or single recipient
   rpc SendUniqueMessage (UniqueMessageRequest) returns (StatusResponse);
 
@@ -145,4 +148,37 @@ message FetchTemplateRequest {
   string templateName = 2;
   int32 pageNumber = 3;
   int32 pageSize = 4;
+}
+
+message MessageProto {
+  string messageId = 1;
+  string sender = 2;
+  repeated string recipients = 3;
+  string message = 4;
+  repeated string recievedBy = 5;
+  repeated string readBy = 6;
+  repeated string respondedBy = 7;
+  repeated string failedRecipients = 8;
+  int64 createdOn = 9;
+  ScheduleInfo scheduleInfo = 10;
+  MediaParameters mediaParameters = 11;
+  map<string, string> buttons = 12;
+  string transactionId = 13;
+}
+
+message MessageList {
+  repeated MessageProto messages = 1;
+  int32 totalCount = 2;
+}
+
+message MessageFilters {
+  string messageId = 1;
+  string sender = 2;
+  string transactionId = 3;
+}
+
+message FetchMessageRequest {
+  MessageFilters filters = 1;
+  int32 pageNumber = 2;
+  int32 pageSize = 3;
 }

--- a/messaging-service.proto
+++ b/messaging-service.proto
@@ -19,9 +19,6 @@ service MessagingService {
   // Supports sending unique messages to multiple recipients or single recipient
   rpc SendUniqueMessage (UniqueMessageRequest) returns (StatusResponse);
 
-  // Get the chat history of a user
-  rpc GetChatHistory (IdRequest) returns (ChatHistory);
-
   // Register a new messaging template, these templates can be used as blueprints for sending messages 
   // and UI rendering in admin panel
   rpc RegisterMessagingTemplate (MessagingTemplate) returns (StatusResponse);
@@ -34,18 +31,55 @@ enum MediaType {
   audio = 2;
 }
 
+enum Category {
+  AUTHENTICATION = 0;
+  MARKETING = 1;
+  UTILITY = 2;
+}
+
+enum ButtonType {
+  None = 1;
+  CallToAction = 2;
+  QuickReply = 3;
+}
+
+// Urls can be static or dynamic, dynamic urls are used to pass parameters to the url
+message Url {
+  enum urlType {
+    static = 0;
+    dynamic = 1;
+  }
+  string link = 1;
+  map<string, string> urlParameters = 2;
+}
+
+// CallToActionButtons are of two types, callPhoneNumber and visitWebsite. 
+message CallToActionButtons {
+  enum actionType {
+    callPhoneNumber = 0;
+    visitWebsite = 1;
+  }
+  string text = 2;
+  string phoneNumber = 3;
+  Url url = 4;
+}
+
+// QuickReplyButtons are used to send quick replies by the user
+message QuickReplyButtons {
+  string text = 1;
+}
+
+message Button {
+  repeated CallToActionButtons callToActionButtons = 1;
+  repeated QuickReplyButtons quickReplyButtons = 2;
+}
+
+// The header can be either text or media, if it is media then the mediaParameters should be used
+
 message MediaParameters {
   MediaType mediaType = 1;
   string link = 2;
   string filename = 3;
-}
-
-message IdRequest {
-  string id = 1;
-}
-
-message StatusResponse {
-  string status = 1;
 }
 
 // Templates are for validation and rendering in admin panel 
@@ -56,7 +90,15 @@ message MessagingTemplate {
   string templateId = 1;
   string templateName = 2;
   MediaParameters mediaParameters = 3;
-  map<string, string> templateParameters = 4;
+  string header = 4;
+  map<strig, string> HeaderParameters = 5;
+  string body = 6;
+  map<string, string> BodyParameters = 7;
+  string footer = 8;
+  Category category = 9;
+  string wabaId = 10; // WhatsApp Business Account ID
+  ButtonType buttonType = 11;
+  Button buttons = 12;
 }
 
 // The UniqueMessageRequest is used to send unique messages to multiple recipients
@@ -69,20 +111,18 @@ message UniqueMessageRequest {
 // The templateParameters are variables that are used in the template
 message MesssageRequest {
   string templateId = 1;
-  map<string, string> templateParameters = 2;
-  MediaParameters mediaParameters = 3;
-  repeated string recipientPhoneNumber = 4;
+  map<string, string> HeaderParameters = 2;
+  map<string, string> BodyParameters = 3;
+  map<string, string> ButtonParameters = 4;  // for dynamic urls
+  MediaParameters mediaParameters = 5;
+  repeated string recipientPhoneNumber = 6;
+  string wabaid = 7; // WhatsApp Business Account ID
 }
 
-message ChatHistory {
-  repeated Message messages = 1;
+message IdRequest {
+  string id = 1;
 }
 
-message Message {
-  string messageId = 1;
-  string senderId = 2;
-  string recipientId = 3;
-  string message = 4;
-  string status = 5;
-  string createdOn = 6;
+message StatusResponse {
+  string status = 1;
 }

--- a/messaging-service.proto
+++ b/messaging-service.proto
@@ -38,27 +38,31 @@ enum Category {
 }
 
 enum ButtonType {
-  None = 1;
-  CallToAction = 2;
-  QuickReply = 3;
+  None = 0;
+  CallToAction = 1;
+  QuickReply = 2;
+}
+
+enum ActionType {
+  callPhoneNumber = 0;
+  visitWebsite = 1;
+}
+
+enum UrlType {
+  static = 0;
+  dynamic = 1;
 }
 
 // Urls can be static or dynamic, dynamic urls are used to pass parameters to the url
 message Url {
-  enum urlType {
-    static = 0;
-    dynamic = 1;
-  }
-  string link = 1;
-  map<string, string> urlParameters = 2;
+  UrlType urlType = 1;
+  string link = 2;
+  map<string, string> urlParameters = 3;
 }
 
 // CallToActionButtons are of two types, callPhoneNumber and visitWebsite. 
 message CallToActionButtons {
-  enum actionType {
-    callPhoneNumber = 0;
-    visitWebsite = 1;
-  }
+  ActionType actionType = 1;
   string text = 2;
   string phoneNumber = 3;
   Url url = 4;
@@ -91,7 +95,7 @@ message MessagingTemplate {
   string templateName = 2;
   MediaParameters mediaParameters = 3;
   string header = 4;
-  map<strig, string> HeaderParameters = 5;
+  map<string, string> HeaderParameters = 5;
   string body = 6;
   map<string, string> BodyParameters = 7;
   string footer = 8;


### PR DESCRIPTION
Added Messaging Service with rpcs to register messaging templates and send whatsapp messages, following rpcs have been added.

1. BroadcastMessage -> To broadcast a message to multiple recepients
2. FetchMessages -> To fetch messages sent over broadcast and get stats such as delivered, read, etc..
3. RegisterMessagingTemplate -> To register a template 
4. FetchMessagingTemplate -> To fetch messaging template using filters 